### PR TITLE
feat: add project workspaces to dashboard

### DIFF
--- a/src/lib/projects.tsx
+++ b/src/lib/projects.tsx
@@ -1,0 +1,293 @@
+import React from 'react'
+
+export type Project = {
+  id: string
+  name: string
+  summary: string
+  focus: string
+  status: string
+  createdAt: string
+  updatedAt: string
+  lastOpenedAt: string
+}
+
+export type CreateProjectInput = {
+  name: string
+  summary?: string
+  focus: string
+}
+
+type ProjectsContextValue = {
+  projects: Project[]
+  activeProjectId: string | null
+  activeProject: Project | null
+  createProject: (input: CreateProjectInput) => Project
+  selectProject: (projectId: string) => Project | null
+  logProjectActivity: (projectId: string) => void
+}
+
+const PROJECTS_STORAGE_KEY = 'nightshift.projects'
+const ACTIVE_PROJECT_STORAGE_KEY = 'nightshift.activeProjectId'
+
+function createId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function sortProjects(projects: Project[]) {
+  return [...projects].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  )
+}
+
+function safeLoadProjects(): Project[] {
+  if (typeof window === 'undefined') {
+    return defaultProjects
+  }
+
+  try {
+    const stored = window.localStorage.getItem(PROJECTS_STORAGE_KEY)
+
+    if (!stored) {
+      return defaultProjects
+    }
+
+    const parsed: unknown = JSON.parse(stored)
+
+    if (!Array.isArray(parsed)) {
+      return defaultProjects
+    }
+
+    const projects: Project[] = []
+
+    for (const item of parsed) {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        typeof (item as Project).id !== 'string' ||
+        typeof (item as Project).name !== 'string'
+      ) {
+        return defaultProjects
+      }
+
+      const project = item as Partial<Project>
+
+      if (
+        typeof project.summary !== 'string' ||
+        typeof project.focus !== 'string' ||
+        typeof project.status !== 'string' ||
+        typeof project.createdAt !== 'string' ||
+        typeof project.updatedAt !== 'string' ||
+        typeof project.lastOpenedAt !== 'string'
+      ) {
+        return defaultProjects
+      }
+
+      projects.push(project as Project)
+    }
+
+    return sortProjects(projects)
+  } catch {
+    return defaultProjects
+  }
+}
+
+function safeLoadActiveProjectId(projects: Project[]): string | null {
+  if (typeof window === 'undefined') {
+    return projects[0]?.id ?? null
+  }
+
+  try {
+    const stored = window.localStorage.getItem(ACTIVE_PROJECT_STORAGE_KEY)
+
+    if (!stored) {
+      return projects[0]?.id ?? null
+    }
+
+    const parsed: unknown = JSON.parse(stored)
+
+    if (typeof parsed !== 'string') {
+      return projects[0]?.id ?? null
+    }
+
+    return projects.some((project) => project.id === parsed) ? parsed : (projects[0]?.id ?? null)
+  } catch {
+    return projects[0]?.id ?? null
+  }
+}
+
+const defaultProjects: Project[] = [
+  {
+    id: 'lunar-interfaces',
+    name: 'Lunar Interfaces',
+    summary: 'Crafting the portal for creators shaping cosmic UI systems and nightly rituals.',
+    focus: 'Prototype the onboarding flow that helps new crews set their vibe rituals.',
+    status: 'Discovery sprint',
+    createdAt: '2024-03-18T09:00:00.000Z',
+    updatedAt: '2024-04-06T14:30:00.000Z',
+    lastOpenedAt: '2024-04-06T14:30:00.000Z',
+  },
+  {
+    id: 'atlas-sessions',
+    name: 'Atlas Sessions',
+    summary: 'A shared vibe journal helping remote facilitators sync across timezones.',
+    focus: 'Ship the weekly recap loop with highlights pulled from every host.',
+    status: 'In-flight',
+    createdAt: '2024-02-26T16:00:00.000Z',
+    updatedAt: '2024-04-03T18:15:00.000Z',
+    lastOpenedAt: '2024-04-04T08:45:00.000Z',
+  },
+  {
+    id: 'aurora-synthesis',
+    name: 'Aurora Synthesis',
+    summary: 'Synth intelligence that surfaces stand-out insights from night research logs.',
+    focus: 'Design the digest view that makes it effortless to share the signal.',
+    status: 'Concept lab',
+    createdAt: '2024-03-05T11:30:00.000Z',
+    updatedAt: '2024-03-29T10:15:00.000Z',
+    lastOpenedAt: '2024-03-29T10:15:00.000Z',
+  },
+]
+
+const ProjectsContext = React.createContext<ProjectsContextValue | undefined>(undefined)
+
+export function ProjectsProvider({ children }: { children: React.ReactNode }) {
+  const initialStateRef = React.useRef<{
+    projects: Project[]
+    activeProjectId: string | null
+  } | null>(null)
+
+  if (initialStateRef.current === null) {
+    const projects = safeLoadProjects()
+    initialStateRef.current = {
+      projects,
+      activeProjectId: safeLoadActiveProjectId(projects),
+    }
+  }
+
+  const [projects, setProjects] = React.useState<Project[]>(() => initialStateRef.current!.projects)
+  const [activeProjectId, setActiveProjectId] = React.useState<string | null>(
+    () => initialStateRef.current!.activeProjectId,
+  )
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      window.localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects))
+    } catch {
+      // Ignore storage errors.
+    }
+  }, [projects])
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      if (activeProjectId) {
+        window.localStorage.setItem(ACTIVE_PROJECT_STORAGE_KEY, JSON.stringify(activeProjectId))
+      } else {
+        window.localStorage.removeItem(ACTIVE_PROJECT_STORAGE_KEY)
+      }
+    } catch {
+      // Ignore storage errors.
+    }
+  }, [activeProjectId])
+
+  const projectsRef = React.useRef(projects)
+
+  React.useEffect(() => {
+    projectsRef.current = projects
+  }, [projects])
+
+  const createProject = React.useCallback((input: CreateProjectInput) => {
+    const now = new Date().toISOString()
+    const project: Project = {
+      id: createId('project'),
+      name: input.name.trim(),
+      summary: input.summary?.trim() || 'Fresh Nightshift idea warming up for its first sprint.',
+      focus: input.focus.trim(),
+      status: 'Kickoff ready',
+      createdAt: now,
+      updatedAt: now,
+      lastOpenedAt: now,
+    }
+
+    setProjects((previous) => sortProjects([project, ...previous]))
+    setActiveProjectId(project.id)
+
+    return project
+  }, [])
+
+  const selectProject = React.useCallback((projectId: string) => {
+    const project = projectsRef.current.find((item) => item.id === projectId) ?? null
+
+    if (!project) {
+      return null
+    }
+
+    setActiveProjectId(projectId)
+    const timestamp = new Date().toISOString()
+
+    setProjects((previous) =>
+      previous.map((item) => (item.id === projectId ? { ...item, lastOpenedAt: timestamp } : item)),
+    )
+
+    return { ...project, lastOpenedAt: timestamp }
+  }, [])
+
+  const logProjectActivity = React.useCallback((projectId: string) => {
+    const timestamp = new Date().toISOString()
+
+    setProjects((previous) => {
+      let didUpdate = false
+
+      const next = previous.map((item) => {
+        if (item.id === projectId) {
+          didUpdate = true
+          return { ...item, updatedAt: timestamp }
+        }
+
+        return item
+      })
+
+      if (!didUpdate) {
+        return previous
+      }
+
+      return sortProjects(next)
+    })
+  }, [])
+
+  const activeProject = React.useMemo(
+    () => projects.find((project) => project.id === activeProjectId) ?? null,
+    [projects, activeProjectId],
+  )
+
+  const value = React.useMemo<ProjectsContextValue>(
+    () => ({
+      projects,
+      activeProjectId,
+      activeProject,
+      createProject,
+      selectProject,
+      logProjectActivity,
+    }),
+    [projects, activeProjectId, activeProject, createProject, selectProject, logProjectActivity],
+  )
+
+  return <ProjectsContext.Provider value={value}>{children}</ProjectsContext.Provider>
+}
+
+export function useProjects() {
+  const context = React.useContext(ProjectsContext)
+
+  if (!context) {
+    throw new Error('useProjects must be used within a ProjectsProvider')
+  }
+
+  return context
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import { ThemeProvider } from '@/components/theme-provider'
 import { AppClerkProvider } from '@/lib/clerk'
+import { ProjectsProvider } from '@/lib/projects'
 
 import { AppRouter } from './router'
 import './styles.css'
@@ -16,7 +17,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <AppClerkProvider>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
-          <AppRouter />
+          <ProjectsProvider>
+            <AppRouter />
+          </ProjectsProvider>
         </ThemeProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,6 +14,7 @@ import { HomeRoute } from './routes/index'
 import { LoginRoute } from './routes/login'
 import { PricingRoute } from './routes/pricing'
 import { SignUpRoute } from './routes/sign-up'
+import { ProjectsRoute } from './routes/projects'
 
 const rootRoute = new RootRoute({
   component: () => (
@@ -57,35 +58,47 @@ const signUpRoute = new Route({
 const dashboardRoute = new Route({
   getParentRoute: () => rootRoute,
   path: 'dashboard',
+  component: () => <Outlet />,
+})
+
+const dashboardProjectsRoute = new Route({
+  getParentRoute: () => dashboardRoute,
+  path: '/',
+  component: ProjectsRoute,
+})
+
+const dashboardProjectLayoutRoute = new Route({
+  getParentRoute: () => dashboardRoute,
+  path: '$projectId',
   component: DashboardLayout,
 })
 
-const dashboardVibePilotRoute = new Route({
-  getParentRoute: () => dashboardRoute,
-  path: 'vibe-pilot',
-  component: DashboardVibePilotRoute,
-})
-
-const dashboardIndexRoute = new Route({
-  getParentRoute: () => dashboardRoute,
+const dashboardProjectIndexRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
   path: '/',
   component: DashboardIndexRoute,
 })
 
-const dashboardJournalRoute = new Route({
-  getParentRoute: () => dashboardRoute,
+const dashboardProjectVibePilotRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
+  path: 'vibe-pilot',
+  component: DashboardVibePilotRoute,
+})
+
+const dashboardProjectJournalRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
   path: 'journal',
   component: DashboardJournalRoute,
 })
 
-const dashboardRitualsRoute = new Route({
-  getParentRoute: () => dashboardRoute,
+const dashboardProjectRitualsRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
   path: 'rituals',
   component: DashboardRitualsRoute,
 })
 
-const dashboardAccountRoute = new Route({
-  getParentRoute: () => dashboardRoute,
+const dashboardProjectAccountRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
   path: 'account',
   component: AccountManagementRoute,
 })
@@ -93,11 +106,14 @@ const dashboardAccountRoute = new Route({
 const routeTree = rootRoute.addChildren([
   marketingRoute.addChildren([homeRoute, pricingRoute, loginRoute, signUpRoute]),
   dashboardRoute.addChildren([
-    dashboardVibePilotRoute,
-    dashboardIndexRoute,
-    dashboardJournalRoute,
-    dashboardRitualsRoute,
-    dashboardAccountRoute,
+    dashboardProjectsRoute,
+    dashboardProjectLayoutRoute.addChildren([
+      dashboardProjectIndexRoute,
+      dashboardProjectVibePilotRoute,
+      dashboardProjectJournalRoute,
+      dashboardProjectRitualsRoute,
+      dashboardProjectAccountRoute,
+    ]),
   ]),
 ])
 

--- a/src/routes/projects.tsx
+++ b/src/routes/projects.tsx
@@ -1,0 +1,288 @@
+import React from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { ArrowRight, Clock, FolderKanban, PlusCircle, Sparkles } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useProjects } from '@/lib/projects'
+import { cn } from '@/lib/utils'
+
+function formatDate(dateInput: string) {
+  const timestamp = Date.parse(dateInput)
+
+  if (Number.isNaN(timestamp)) {
+    return '—'
+  }
+
+  return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(timestamp)
+}
+
+function formatRelativeTime(dateInput: string) {
+  const timestamp = Date.parse(dateInput)
+
+  if (Number.isNaN(timestamp)) {
+    return 'just now'
+  }
+
+  const diff = Date.now() - timestamp
+
+  if (diff <= 0) {
+    return 'just now'
+  }
+
+  const minutes = Math.floor(diff / (60 * 1000))
+
+  if (minutes < 1) {
+    return 'just now'
+  }
+
+  if (minutes === 1) {
+    return '1 minute ago'
+  }
+
+  if (minutes < 60) {
+    return `${minutes} minutes ago`
+  }
+
+  const hours = Math.floor(minutes / 60)
+
+  if (hours === 1) {
+    return '1 hour ago'
+  }
+
+  if (hours < 24) {
+    return `${hours} hours ago`
+  }
+
+  const days = Math.floor(hours / 24)
+
+  if (days === 1) {
+    return '1 day ago'
+  }
+
+  if (days < 7) {
+    return `${days} days ago`
+  }
+
+  return formatDate(dateInput)
+}
+
+export function ProjectsRoute() {
+  const navigate = useNavigate()
+  const { projects, activeProjectId, createProject, selectProject } = useProjects()
+  const [name, setName] = React.useState('')
+  const [summary, setSummary] = React.useState('')
+  const [focus, setFocus] = React.useState('')
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  const sortedProjects = projects
+  const projectCountLabel = `${projects.length} project${projects.length === 1 ? '' : 's'}`
+
+  const resetForm = () => {
+    setName('')
+    setSummary('')
+    setFocus('')
+  }
+
+  const handleCreateProject = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedName = name.trim()
+    const trimmedFocus = focus.trim()
+
+    if (!trimmedName || !trimmedFocus || isSubmitting) {
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const project = createProject({
+        name: trimmedName,
+        summary,
+        focus: trimmedFocus,
+      })
+
+      resetForm()
+      await navigate({ to: '/dashboard/$projectId/journal', params: { projectId: project.id } })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleOpenProject = async (projectId: string) => {
+    const project = selectProject(projectId)
+
+    if (!project) {
+      return
+    }
+
+    await navigate({ to: '/dashboard/$projectId/journal', params: { projectId: projectId } })
+  }
+
+  const isFormValid = name.trim().length > 0 && focus.trim().length > 0
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-3 text-center md:items-start md:text-left">
+        <Badge variant="outline" className="border-primary/60 text-primary">
+          Nightshift projects
+        </Badge>
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Choose a project to enter Nightshift mode
+        </h1>
+        <p className="text-base text-muted-foreground sm:text-lg">
+          Each project keeps its own journal, rituals, and AI copilots so your focus stays precise.
+        </p>
+      </div>
+
+      <Card className="mx-auto w-full max-w-4xl border-muted/70">
+        <CardHeader className="space-y-3">
+          <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+            <PlusCircle className="h-4 w-4 text-primary" />
+            Start a fresh project
+          </div>
+          <CardTitle className="text-2xl">Spin up a new Nightshift space</CardTitle>
+          <CardDescription>
+            Give your idea a name, set the immediate focus, and we&apos;ll prep a dedicated
+            dashboard for deep work.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-5" onSubmit={handleCreateProject}>
+            <div className="grid gap-2">
+              <Label htmlFor="project-name">Project name</Label>
+              <Input
+                id="project-name"
+                placeholder="e.g. Nebula ritual planner"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="project-focus">Current focus</Label>
+              <Input
+                id="project-focus"
+                placeholder="e.g. Plan the onboarding ceremony for new collaborators"
+                value={focus}
+                onChange={(event) => setFocus(event.target.value)}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="project-summary">Vibe summary (optional)</Label>
+              <textarea
+                id="project-summary"
+                placeholder="Share the intent, audience, or rituals you want to explore."
+                value={summary}
+                onChange={(event) => setSummary(event.target.value)}
+                className="min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                Projects help you capture journals, rituals, and AI prompts for each initiative.
+              </p>
+              <Button type="submit" disabled={!isFormValid || isSubmitting}>
+                Launch project
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">Your projects</h2>
+            <p className="text-sm text-muted-foreground">
+              Select a project to open its dedicated Nightshift dashboard.
+            </p>
+          </div>
+          <Badge variant="secondary" className="w-fit bg-secondary/80 text-secondary-foreground">
+            {projectCountLabel}
+          </Badge>
+        </div>
+
+        {sortedProjects.length ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {sortedProjects.map((project) => {
+              const isActive = project.id === activeProjectId
+
+              return (
+                <Card
+                  key={project.id}
+                  className={cn(
+                    'border-muted/70 transition hover:border-primary/50 hover:shadow-sm',
+                    isActive && 'border-primary/60 bg-primary/5 shadow-sm',
+                  )}
+                >
+                  <CardHeader className="space-y-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <CardTitle className="text-xl text-foreground">{project.name}</CardTitle>
+                        <CardDescription>{project.summary}</CardDescription>
+                      </div>
+                      <Badge variant="outline" className="shrink-0 border-primary/40 text-primary">
+                        {project.status}
+                      </Badge>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-sm text-muted-foreground">
+                    <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                      <Sparkles className="h-3.5 w-3.5" />
+                      {project.focus}
+                    </div>
+                    <div className="flex flex-col gap-2 text-xs sm:flex-row sm:items-center sm:justify-between">
+                      <div className="inline-flex items-center gap-2">
+                        <Clock className="h-3.5 w-3.5 text-primary" />
+                        <span>Updated {formatDate(project.updatedAt)}</span>
+                      </div>
+                      <span className="inline-flex items-center gap-2">
+                        <FolderKanban className="h-3.5 w-3.5 text-primary" />
+                        Last opened {formatRelativeTime(project.lastOpenedAt)}
+                      </span>
+                    </div>
+                  </CardContent>
+                  <CardFooter className="flex items-center justify-between gap-3">
+                    <p className="text-xs text-muted-foreground">
+                      {isActive ? 'Active now' : 'Keep momentum in this workspace'}
+                    </p>
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => void handleOpenProject(project.id)}
+                    >
+                      Enter project
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+                  </CardFooter>
+                </Card>
+              )
+            })}
+          </div>
+        ) : (
+          <Card className="border-dashed border-muted/70">
+            <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-sm text-muted-foreground">
+              <FolderKanban className="h-6 w-6 text-primary" />
+              <p>
+                You don&apos;t have any projects yet. Spin up a new one to unlock your dashboards.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/routes/vibe-pilot.tsx
+++ b/src/routes/vibe-pilot.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useParams } from '@tanstack/react-router'
 import { Bot, ClipboardList, MessageSquarePlus, RefreshCcw, Rocket, Sparkles } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
@@ -16,6 +17,7 @@ import { Label } from '@/components/ui/label'
 import { requestVibePilotCompletion, type VibePilotConfig } from '@/lib/vibe-pilot-ai'
 import type { VibePilotChatMessage, VibePilotMode } from '@/lib/vibe-pilot-ai'
 import { cn } from '@/lib/utils'
+import { useProjects } from '@/lib/projects'
 
 const toneOptions = [
   { value: 'encouraging product coach', label: 'Encouraging coach' },
@@ -86,6 +88,8 @@ export function DashboardVibePilotRoute() {
   const [projectName, setProjectName] = React.useState('')
   const [audience, setAudience] = React.useState('')
   const [focusDetails, setFocusDetails] = React.useState('')
+  const [hasEditedProjectName, setHasEditedProjectName] = React.useState(false)
+  const [hasEditedFocusDetails, setHasEditedFocusDetails] = React.useState(false)
   const [tone, setTone] = React.useState<(typeof toneOptions)[number]['value']>(
     toneOptions[0].value,
   )
@@ -95,6 +99,45 @@ export function DashboardVibePilotRoute() {
   const [isGenerating, setIsGenerating] = React.useState(false)
   const [kickoffStatus, setKickoffStatus] = React.useState<KickoffStatus>('idle')
   const [error, setError] = React.useState<string | null>(null)
+
+  const { projectId } = useParams({ from: '/dashboard/$projectId/vibe-pilot' })
+  const { activeProject, logProjectActivity } = useProjects()
+  const activeProjectName = activeProject?.name ?? ''
+  const activeProjectSummary = activeProject?.summary ?? ''
+  const activeProjectFocus = activeProject?.focus ?? ''
+  const projectHeroName = activeProjectName || 'your Nightshift project'
+  const heroDescription =
+    activeProjectSummary ||
+    'Spin up an AI copilot that adapts to your goals—generate detailed design docs or partner on growth strategy in minutes.'
+  const heroFocusLine = activeProjectFocus ? ` We’ll keep momentum on ${activeProjectFocus}.` : ''
+
+  const hasPrefilledProjectIdRef = React.useRef<string | null>(null)
+
+  React.useEffect(() => {
+    if (!projectId) {
+      return
+    }
+
+    if (hasPrefilledProjectIdRef.current !== projectId) {
+      hasPrefilledProjectIdRef.current = projectId
+      setHasEditedProjectName(false)
+      setHasEditedFocusDetails(false)
+    }
+
+    if (!hasEditedProjectName && activeProjectName) {
+      setProjectName(activeProjectName)
+    }
+
+    if (!hasEditedFocusDetails && activeProjectFocus) {
+      setFocusDetails(activeProjectFocus)
+    }
+  }, [
+    projectId,
+    activeProjectName,
+    activeProjectFocus,
+    hasEditedProjectName,
+    hasEditedFocusDetails,
+  ])
 
   const messagesRef = React.useRef<ChatMessage[]>([])
   const endRef = React.useRef<HTMLDivElement | null>(null)
@@ -243,6 +286,9 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
         tone,
       }
       setSessionConfig(config)
+      if (projectId) {
+        logProjectActivity(projectId)
+      }
       setPhase('chat')
       setKickoffStatus('running')
       setMessages([])
@@ -288,6 +334,8 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
     setAudience('')
     setMode('design')
     setTone(toneOptions[0].value)
+    setHasEditedProjectName(false)
+    setHasEditedFocusDetails(false)
   }
 
   const canProceed = React.useMemo(() => {
@@ -308,15 +356,15 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
 
   const wizardDescription = React.useMemo(() => {
     if (stepIndex === 0) {
-      return 'Choose how Vibe Pilot should collaborate on this session.'
+      return `Choose how Vibe Pilot should collaborate on ${projectHeroName}'s next session.`
     }
 
     if (stepIndex === 1) {
-      return 'Tell Vibe Pilot what you are building and who it is for.'
+      return `Tell Vibe Pilot what ${projectHeroName} is building and who it's for.`
     }
 
-    return 'Share the details you already have so the AI can kick things off in the right direction.'
-  }, [stepIndex])
+    return `Share the context you already have so the AI can kick things off with ${projectHeroName}'s goals in mind.`
+  }, [stepIndex, projectHeroName])
 
   const chatHeaderCopy = React.useMemo(() => {
     if (!sessionConfig) {
@@ -419,11 +467,11 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
           </span>
         </div>
         <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-          Guide your next product move with AI
+          Guide the next move for {projectHeroName} with AI
         </h1>
         <p className="text-base text-muted-foreground sm:text-lg">
-          Spin up an AI copilot that adapts to your goals—generate detailed design docs or partner
-          on growth strategy in minutes.
+          {heroDescription}
+          {heroFocusLine}
         </p>
       </div>
 
@@ -437,7 +485,7 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
               </CardTitle>
               <CardDescription className="text-base text-muted-foreground">
                 Pick a collaboration style and we will collect the right context before launching
-                straight into a tailored ChatGPT session.
+                straight into a tailored ChatGPT session for {projectHeroName}.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -542,8 +590,11 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
                   <Input
                     id="project-name"
                     value={projectName}
-                    onChange={(event) => setProjectName(event.target.value)}
-                    placeholder="e.g. Nightshift mobile companion"
+                    onChange={(event) => {
+                      setProjectName(event.target.value)
+                      setHasEditedProjectName(true)
+                    }}
+                    placeholder={activeProjectName || 'e.g. Nightshift mobile companion'}
                     required
                   />
                 </div>
@@ -570,11 +621,18 @@ Audience: ${sessionConfig.audience || 'Not specified yet.'}`
                   <textarea
                     id="project-details"
                     value={focusDetails}
-                    onChange={(event) => setFocusDetails(event.target.value)}
+                    onChange={(event) => {
+                      setFocusDetails(event.target.value)
+                      setHasEditedFocusDetails(true)
+                    }}
                     placeholder={
                       mode === 'design'
-                        ? 'List the core features, flows, and constraints you want to cover.'
-                        : 'What areas should we co-create on? Pricing, partnerships, onboarding, community?'
+                        ? activeProjectFocus
+                          ? `List the core features, flows, and constraints you want to cover for ${activeProjectFocus}.`
+                          : 'List the core features, flows, and constraints you want to cover.'
+                        : activeProjectFocus
+                          ? `What areas should we co-create on to move ${activeProjectFocus} forward?`
+                          : 'What areas should we co-create on? Pricing, partnerships, onboarding, community?'
                     }
                     className="min-h-[160px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     required


### PR DESCRIPTION
## Summary
- add a projects context provider that persists workspaces and activity locally
- create a project selection screen with creation form before entering the dashboard
- scope dashboard routes, journal, rituals, and Vibe Pilot flows to the active project

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d132d622548329b0d771cc75263b5c