### PR TITLE
Remove Playwright CI job and gate commits on passing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Run type check
         run: npm run typecheck
 
-  build:
-    name: Test and Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     needs:
       - lint
@@ -63,8 +63,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Run unit tests
         run: npm run test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build project
         run: npm run build
@@ -78,27 +98,3 @@ jobs:
             dist
           if-no-files-found: warn
 
-  e2e:
-    name: Playwright Tests
-    runs-on: ubuntu-latest
-    needs:
-      - lint
-      - typecheck
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
-      - name: Run Playwright tests
-        run: npm run test:e2e

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -e
+
 npm run lint:staged
 npm run lint
 npm run test


### PR DESCRIPTION
## Summary
- replace the combined test/build job with distinct unit test and build jobs
- remove the Playwright end-to-end test job from the CI workflow
- tighten the Husky pre-commit hook by exiting immediately when a command fails

## Testing
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35a94c948832993355dad1fcb67c9