### PR TITLE
feat: add design document builder

### DIFF
--- a/playwright/tests/design-document.spec.ts
+++ b/playwright/tests/design-document.spec.ts
@@ -1,0 +1,24 @@
+import { test } from '@playwright/test'
+
+const PROJECT_ID = 'lunar-interfaces'
+
+test('design document builder screenshot', async ({ page }) => {
+  await page.goto(`/dashboard/${PROJECT_ID}/design-document`)
+
+  await page.getByRole('heading', { name: 'Design Document Builder' }).waitFor()
+
+  const chatInput = page.getByPlaceholder(
+    'Describe what you are trying to plan. Share goals, audience, or open questions.',
+  )
+  await chatInput.fill('We need an onboarding flow for new creators with clear milestones.')
+  await chatInput.press('Enter')
+
+  await page.getByText('Design document').first().waitFor()
+
+  await page.waitForTimeout(500)
+
+  await page.screenshot({
+    path: 'playwright-artifacts/design-document-builder.png',
+    fullPage: true,
+  })
+})

--- a/src/components/ladel/design-document-chat.tsx
+++ b/src/components/ladel/design-document-chat.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import { Loader2, SendHorizonal } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+export type DesignDocumentChatMessage = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+}
+
+type DesignDocumentChatProps = {
+  messages: DesignDocumentChatMessage[]
+  onSend: (message: string) => Promise<void> | void
+  isGenerating: boolean
+  disabled?: boolean
+  error?: string | null
+  placeholder?: string
+}
+
+export function DesignDocumentChat({
+  messages,
+  onSend,
+  isGenerating,
+  disabled = false,
+  error,
+  placeholder = 'Describe what you are trying to plan. Share goals, audience, or open questions.',
+}: DesignDocumentChatProps) {
+  const [value, setValue] = React.useState('')
+  const [localError, setLocalError] = React.useState<string | null>(null)
+  const listRef = React.useRef<HTMLDivElement | null>(null)
+
+  React.useEffect(() => {
+    const list = listRef.current
+
+    if (!list) {
+      return
+    }
+
+    list.scrollTo({ top: list.scrollHeight })
+  }, [messages])
+
+  const attemptSend = async () => {
+    const trimmed = value.trim()
+
+    if (!trimmed || disabled || isGenerating) {
+      if (!trimmed) {
+        setLocalError('Add a quick note so I can help refine it.')
+      }
+      return
+    }
+
+    try {
+      setLocalError(null)
+      await onSend(trimmed)
+      setValue('')
+    } catch (submissionError) {
+      const message =
+        submissionError instanceof Error
+          ? submissionError.message
+          : 'Something went wrong. Please try again.'
+      setLocalError(message)
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    await attemptSend()
+  }
+
+  const activeError = error ?? localError
+
+  return (
+    <div className="flex h-full flex-col rounded-xl border border-muted/60 bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b border-muted/50 px-4 py-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">AI partner</p>
+          <p className="text-xs text-muted-foreground">
+            I&apos;ll keep the tone simple and translate our chat into a polished doc.
+          </p>
+        </div>
+        {isGenerating ? (
+          <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Thinking
+          </div>
+        ) : null}
+      </div>
+      <div ref={listRef} className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}
+          >
+            <div
+              className={cn(
+                'max-w-[85%] rounded-lg border px-3 py-2 text-sm shadow-sm transition',
+                message.role === 'user'
+                  ? 'rounded-br-none bg-primary text-primary-foreground border-primary/70'
+                  : 'rounded-bl-none border-muted bg-background text-foreground',
+              )}
+            >
+              <p className="whitespace-pre-wrap leading-relaxed">{message.content}</p>
+            </div>
+          </div>
+        ))}
+        {messages.length === 0 ? (
+          <div className="text-sm text-muted-foreground">
+            Tell me about the idea and I&apos;ll start a focused document for your team.
+          </div>
+        ) : null}
+      </div>
+      <div className="border-t border-muted/50 px-4 py-3">
+        <form className="space-y-3" onSubmit={handleSubmit}>
+          <Textarea
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder={placeholder}
+            rows={4}
+            disabled={disabled || isGenerating}
+            className="resize-none text-sm"
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                void attemptSend()
+              }
+            }}
+          />
+          {activeError ? (
+            <p className="text-xs font-medium text-destructive">{activeError}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Press Enter to send, Shift + Enter for a new line.
+            </p>
+          )}
+          <div className="flex items-center justify-end">
+            <Button type="submit" size="sm" disabled={disabled || isGenerating} className="gap-1">
+              {isGenerating ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <SendHorizonal className="h-3.5 w-3.5" />
+              )}
+              Send
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ladel/design-document-markdown-panel.tsx
+++ b/src/components/ladel/design-document-markdown-panel.tsx
@@ -1,0 +1,239 @@
+import React from 'react'
+import { Check, FileText, Loader2, RotateCcw, Save, ShieldCheck } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+import { DesignDocumentPreview } from './design-document-preview'
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+
+type DesignDocumentMarkdownPanelProps = {
+  value: string
+  onChange: (value: string) => void
+  status: 'draft' | 'complete'
+  lastSavedAt: string | null
+  autoSaveState: SaveState
+  manualSaveState: SaveState
+  finalizeState: SaveState
+  onManualSave: () => Promise<void> | void
+  onReset: () => Promise<void> | void
+  onFinalize: () => Promise<void> | void
+  disabled?: boolean
+  activeView?: 'preview' | 'editor'
+  onViewChange?: (view: 'preview' | 'editor') => void
+  hideSwitcher?: boolean
+}
+
+export function DesignDocumentMarkdownPanel({
+  value,
+  onChange,
+  status,
+  lastSavedAt,
+  autoSaveState,
+  manualSaveState,
+  finalizeState,
+  onManualSave,
+  onReset,
+  onFinalize,
+  disabled = false,
+  activeView,
+  onViewChange,
+  hideSwitcher = false,
+}: DesignDocumentMarkdownPanelProps) {
+  const [internalView, setInternalView] = React.useState<'preview' | 'editor'>('preview')
+  const currentView = activeView ?? internalView
+
+  const setView = React.useCallback(
+    (view: 'preview' | 'editor') => {
+      if (onViewChange) {
+        onViewChange(view)
+      } else {
+        setInternalView(view)
+      }
+    },
+    [onViewChange],
+  )
+
+  React.useEffect(() => {
+    if (status === 'complete') {
+      setView('preview')
+    }
+  }, [status, setView])
+
+  const saveLabel = React.useMemo(() => {
+    if (autoSaveState === 'saving') {
+      return 'Saving draft…'
+    }
+
+    if (autoSaveState === 'error') {
+      return 'Auto-save failed. Use manual save to retry.'
+    }
+
+    if (autoSaveState === 'saved' && lastSavedAt) {
+      return `Saved ${formatRelativeTime(lastSavedAt)}`
+    }
+
+    if (lastSavedAt) {
+      return `Last saved ${formatRelativeTime(lastSavedAt)}`
+    }
+
+    return 'Draft not saved yet'
+  }, [autoSaveState, lastSavedAt])
+
+  return (
+    <div className="flex h-full flex-col rounded-xl border border-muted/60 bg-card shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b border-muted/50 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <FileText className="h-4 w-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">Design document</p>
+            <p className="text-xs text-muted-foreground">
+              Live preview synced with every AI update.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {autoSaveState === 'saving' ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Check className="h-3.5 w-3.5" />
+          )}
+          {saveLabel}
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 px-4 py-3">
+        {hideSwitcher ? null : (
+          <div className="inline-flex rounded-lg border border-muted/70 bg-muted/30 p-1 text-xs font-medium">
+            <button
+              type="button"
+              className={cn(
+                'flex-1 rounded-md px-3 py-1 transition data-[active=true]:bg-background data-[active=true]:text-foreground',
+                currentView === 'preview' ? 'data-[active=true]' : 'text-muted-foreground',
+              )}
+              data-active={currentView === 'preview'}
+              onClick={() => setView('preview')}
+            >
+              Preview
+            </button>
+            <button
+              type="button"
+              className={cn(
+                'flex-1 rounded-md px-3 py-1 transition data-[active=true]:bg-background data-[active=true]:text-foreground',
+                status === 'complete' ? 'cursor-not-allowed text-muted-foreground opacity-60' : '',
+                currentView === 'editor' ? 'data-[active=true]' : 'text-muted-foreground',
+              )}
+              onClick={() => {
+                if (status === 'complete') {
+                  return
+                }
+                setView('editor')
+              }}
+              aria-disabled={status === 'complete'}
+            >
+              Editor
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-hidden rounded-lg border border-muted/70 bg-background">
+          <div className="h-full overflow-y-auto p-4">
+            {currentView === 'preview' || status === 'complete' ? (
+              <DesignDocumentPreview source={value} />
+            ) : (
+              <Textarea
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                disabled={disabled}
+                className="min-h-[420px] w-full resize-y border-none p-0 text-sm focus-visible:ring-0"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 border-t border-muted/50 px-4 py-3 text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>Status: {status === 'complete' ? 'Finalized' : 'Draft in progress'}</span>
+          {status === 'complete' ? (
+            <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+              <ShieldCheck className="h-3.5 w-3.5" /> Locked for teammates
+            </span>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {status === 'complete' ? (
+            <Button variant="outline" size="sm" onClick={() => onReset()} className="gap-1">
+              <RotateCcw className="h-3.5 w-3.5" /> Delete &amp; start over
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onReset()}
+                className="gap-1 text-muted-foreground"
+                disabled={disabled}
+              >
+                <RotateCcw className="h-3.5 w-3.5" /> Reset
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onManualSave()}
+                disabled={disabled}
+                className="gap-1"
+              >
+                {manualSaveState === 'saving' ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                Manual save
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => onFinalize()}
+                disabled={disabled || finalizeState === 'saving' || !value.trim()}
+                className="gap-1"
+              >
+                {finalizeState === 'saving' ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Check className="h-3.5 w-3.5" />
+                )}
+                Finalize document
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatRelativeTime(timestamp: string) {
+  const date = new Date(timestamp)
+  const now = Date.now()
+  const diff = Math.max(0, now - date.getTime())
+
+  if (diff < 60 * 1000) {
+    return 'just now'
+  }
+
+  if (diff < 60 * 60 * 1000) {
+    const minutes = Math.round(diff / (60 * 1000))
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  }
+
+  if (diff < 24 * 60 * 60 * 1000) {
+    const hours = Math.round(diff / (60 * 60 * 1000))
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}

--- a/src/components/ladel/design-document-preview.tsx
+++ b/src/components/ladel/design-document-preview.tsx
@@ -2,12 +2,122 @@ import React from 'react'
 import { compile, run } from '@mdx-js/mdx'
 import remarkGfm from 'remark-gfm'
 import * as runtime from 'react/jsx-runtime'
+import type { Plugin } from 'unified'
+import { SKIP, visit } from 'unist-util-visit'
+import type { Root, Content, Code, InlineCode, Text } from 'mdast'
+import type {
+  MdxFlowExpression,
+  MdxJsxFlowElement,
+  MdxJsxTextElement,
+  MdxTextExpression,
+} from 'mdast-util-mdx'
+import type { Parent } from 'unist'
 
 import { cn } from '@/lib/utils'
 
 type DesignDocumentPreviewProps = {
   source: string
   className?: string
+}
+
+type MutableParent = Parent & { children: Content[] }
+
+function replaceNode(parent: MutableParent, index: number, replacement: Content | null): void {
+  if (replacement) {
+    parent.children.splice(index, 1, replacement)
+  } else {
+    parent.children.splice(index, 1)
+  }
+}
+
+const stripUnsafeMdx: Plugin<[], Root> = () => (tree) => {
+  visit(tree, (node, index, parent) => {
+    if (!parent || typeof index !== 'number') {
+      return
+    }
+
+    const mutableParent = parent as MutableParent
+
+    switch (node.type) {
+      case 'mdxjsEsm': {
+        replaceNode(mutableParent, index, null)
+        return [SKIP, index]
+      }
+      case 'mdxFlowExpression': {
+        const flowExpression = node as MdxFlowExpression
+        const codeNode: Code = {
+          type: 'code',
+          lang: 'mdx',
+          value: `{${flowExpression.value}}`,
+        }
+        replaceNode(mutableParent, index, codeNode)
+        return [SKIP, index]
+      }
+      case 'mdxTextExpression': {
+        const textExpression = node as MdxTextExpression
+        const inlineExpression: InlineCode = {
+          type: 'inlineCode',
+          value: `{${textExpression.value}}`,
+        }
+        replaceNode(mutableParent, index, inlineExpression)
+        return [SKIP, index]
+      }
+      case 'mdxJsxFlowElement':
+      case 'mdxJsxTextElement': {
+        const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement
+        const placeholder: Text = {
+          type: 'text',
+          value: jsxNode.name ? `<${jsxNode.name} />` : '<mdx-element />',
+        }
+        replaceNode(mutableParent, index, placeholder)
+        return [SKIP, index]
+      }
+      case 'html': {
+        const htmlNode = node as unknown as { value: string }
+        const safeHtml: Text = {
+          type: 'text',
+          value: htmlNode.value,
+        }
+        replaceNode(mutableParent, index, safeHtml)
+        return [SKIP, index]
+      }
+      default:
+        return
+    }
+  })
+}
+
+const safeComponents = {
+  a: ({ href, ...props }: React.ComponentProps<'a'>) => {
+    if (!href || !isSafeHref(href)) {
+      return <span {...props} />
+    }
+
+    const isHashLink = href.startsWith('#')
+    return (
+      <a
+        href={href}
+        {...props}
+        rel={isHashLink ? undefined : 'noreferrer noopener'}
+        target={isHashLink ? undefined : '_blank'}
+      />
+    )
+  },
+}
+
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+function isSafeHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://example.com')
+    if (url.origin === 'https://example.com') {
+      return true
+    }
+
+    return SAFE_PROTOCOLS.has(url.protocol)
+  } catch {
+    return false
+  }
 }
 
 export function DesignDocumentPreview({ source, className }: DesignDocumentPreviewProps) {
@@ -35,13 +145,13 @@ export function DesignDocumentPreview({ source, className }: DesignDocumentPrevi
 
       try {
         const compiled = await compile(source, {
-          remarkPlugins: [remarkGfm],
+          remarkPlugins: [remarkGfm, stripUnsafeMdx],
           outputFormat: 'function-body',
         })
 
         const module = await run(compiled, {
           ...runtime,
-          useMDXComponents: () => ({}),
+          useMDXComponents: () => safeComponents,
         })
 
         if (!cancelled) {

--- a/src/components/ladel/design-document-preview.tsx
+++ b/src/components/ladel/design-document-preview.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { compile, run } from '@mdx-js/mdx'
+import remarkGfm from 'remark-gfm'
+import * as runtime from 'react/jsx-runtime'
+
+import { cn } from '@/lib/utils'
+
+type DesignDocumentPreviewProps = {
+  source: string
+  className?: string
+}
+
+export function DesignDocumentPreview({ source, className }: DesignDocumentPreviewProps) {
+  const [Component, setComponent] = React.useState<React.ComponentType | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    async function renderMarkdown() {
+      if (!source.trim()) {
+        function PreviewPlaceholder() {
+          return (
+            <p className="text-sm text-muted-foreground">
+              Start chatting or editing to see the live preview.
+            </p>
+          )
+        }
+
+        PreviewPlaceholder.displayName = 'PreviewPlaceholder'
+        setComponent(() => PreviewPlaceholder)
+        setError(null)
+        return
+      }
+
+      try {
+        const compiled = await compile(source, {
+          remarkPlugins: [remarkGfm],
+          outputFormat: 'function-body',
+        })
+
+        const module = await run(compiled, {
+          ...runtime,
+          useMDXComponents: () => ({}),
+        })
+
+        if (!cancelled) {
+          const PreviewComponent = (module as { default: React.ComponentType }).default
+          PreviewComponent.displayName =
+            PreviewComponent.displayName || 'DesignDocumentPreviewContent'
+          setComponent(() => PreviewComponent)
+          setError(null)
+        }
+      } catch (renderError) {
+        if (cancelled) {
+          return
+        }
+
+        const message =
+          renderError instanceof Error
+            ? renderError.message
+            : 'Unable to render the markdown preview.'
+        setError(message)
+        setComponent(null)
+      }
+    }
+
+    void renderMarkdown()
+
+    return () => {
+      cancelled = true
+    }
+  }, [source])
+
+  if (error) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive',
+          className,
+        )}
+      >
+        Preview error: {error}
+      </div>
+    )
+  }
+
+  if (!Component) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border border-muted/60 bg-background/70 p-4 text-sm text-muted-foreground',
+          className,
+        )}
+      >
+        Building preview…
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('prose prose-sm max-w-none dark:prose-invert', className)}>
+      <Component />
+    </div>
+  )
+}

--- a/src/components/ladel/design-document-workspace.tsx
+++ b/src/components/ladel/design-document-workspace.tsx
@@ -1,0 +1,166 @@
+import React from 'react'
+
+import { DesignDocumentChat, type DesignDocumentChatMessage } from './design-document-chat'
+import { DesignDocumentMarkdownPanel } from './design-document-markdown-panel'
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+
+type DesignDocumentWorkspaceProps = {
+  chatMessages: DesignDocumentChatMessage[]
+  onSendMessage: (message: string) => Promise<void> | void
+  chatIsGenerating: boolean
+  chatError?: string | null
+  chatDisabled?: boolean
+  markdownValue: string
+  onMarkdownChange: (value: string) => void
+  markdownStatus: 'draft' | 'complete'
+  lastSavedAt: string | null
+  autoSaveState: SaveState
+  manualSaveState: SaveState
+  finalizeState: SaveState
+  onManualSave: () => Promise<void> | void
+  onReset: () => Promise<void> | void
+  onFinalize: () => Promise<void> | void
+  showDocumentPanel: boolean
+}
+
+export function DesignDocumentWorkspace({
+  chatMessages,
+  onSendMessage,
+  chatIsGenerating,
+  chatError,
+  chatDisabled = false,
+  markdownValue,
+  onMarkdownChange,
+  markdownStatus,
+  lastSavedAt,
+  autoSaveState,
+  manualSaveState,
+  finalizeState,
+  onManualSave,
+  onReset,
+  onFinalize,
+  showDocumentPanel,
+}: DesignDocumentWorkspaceProps) {
+  const [mobileTab, setMobileTab] = React.useState<'chat' | 'preview' | 'editor'>('chat')
+  const isEditorAvailable = showDocumentPanel && markdownStatus !== 'complete'
+
+  React.useEffect(() => {
+    if (!showDocumentPanel && mobileTab !== 'chat') {
+      setMobileTab('chat')
+    }
+  }, [showDocumentPanel, mobileTab])
+
+  React.useEffect(() => {
+    if (markdownStatus === 'complete' && mobileTab === 'editor') {
+      setMobileTab('preview')
+    }
+  }, [markdownStatus, mobileTab])
+
+  const tabCount = showDocumentPanel ? 3 : 1
+
+  const markdownPanelProps = {
+    value: markdownValue,
+    onChange: onMarkdownChange,
+    status: markdownStatus,
+    lastSavedAt,
+    autoSaveState,
+    manualSaveState,
+    finalizeState,
+    onManualSave,
+    onReset,
+    onFinalize,
+    disabled: chatDisabled,
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6">
+      <div className="hidden h-full min-h-[560px] w-full gap-6 md:grid md:grid-cols-2">
+        <DesignDocumentChat
+          messages={chatMessages}
+          onSend={onSendMessage}
+          isGenerating={chatIsGenerating}
+          error={chatError ?? undefined}
+          disabled={chatDisabled}
+        />
+        {showDocumentPanel ? (
+          <DesignDocumentMarkdownPanel {...markdownPanelProps} />
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-muted/60 bg-card text-sm text-muted-foreground">
+            Start the chat to open a shared markdown workspace.
+          </div>
+        )}
+      </div>
+
+      <div className="flex h-full flex-1 flex-col gap-4 md:hidden">
+        <div
+          className="grid overflow-hidden rounded-xl border border-muted/60 bg-card text-sm font-medium"
+          style={{ gridTemplateColumns: `repeat(${tabCount}, minmax(0, 1fr))` }}
+        >
+          <button
+            type="button"
+            className={getMobileTriggerClass(mobileTab === 'chat')}
+            onClick={() => setMobileTab('chat')}
+          >
+            Chat
+          </button>
+          {showDocumentPanel ? (
+            <>
+              <button
+                type="button"
+                className={getMobileTriggerClass(mobileTab === 'preview')}
+                onClick={() => setMobileTab('preview')}
+              >
+                Preview
+              </button>
+              <button
+                type="button"
+                className={getMobileTriggerClass(mobileTab === 'editor', !isEditorAvailable)}
+                onClick={() => {
+                  if (!isEditorAvailable) {
+                    return
+                  }
+                  setMobileTab('editor')
+                }}
+                aria-disabled={!isEditorAvailable}
+              >
+                Editor
+              </button>
+            </>
+          ) : null}
+        </div>
+        <div className="flex-1">
+          {mobileTab === 'chat' || !showDocumentPanel ? (
+            <DesignDocumentChat
+              messages={chatMessages}
+              onSend={onSendMessage}
+              isGenerating={chatIsGenerating}
+              error={chatError ?? undefined}
+              disabled={chatDisabled}
+            />
+          ) : null}
+          {mobileTab === 'preview' && showDocumentPanel ? (
+            <DesignDocumentMarkdownPanel
+              {...markdownPanelProps}
+              hideSwitcher
+              activeView="preview"
+            />
+          ) : null}
+          {mobileTab === 'editor' && showDocumentPanel ? (
+            <DesignDocumentMarkdownPanel {...markdownPanelProps} hideSwitcher activeView="editor" />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getMobileTriggerClass(active: boolean, disabled = false) {
+  return [
+    'border-r border-muted/60 px-3 py-2 text-center transition last:border-r-0',
+    active ? 'bg-background text-foreground' : 'bg-muted/40 text-muted-foreground',
+    disabled ? 'cursor-not-allowed opacity-60' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import {
 } from './routes/dashboard'
 import { DashboardVibePilotRoute } from './routes/vibe-pilot'
 import { AccountManagementRoute } from './routes/account'
+import { DashboardDesignDocumentRoute } from './routes/design-document'
 import { MarketingLayout } from './routes/marketing-layout'
 import { HomeRoute } from './routes/index'
 import { LoginRoute } from './routes/login'
@@ -85,6 +86,12 @@ const dashboardProjectVibePilotRoute = new Route({
   component: DashboardVibePilotRoute,
 })
 
+const dashboardProjectDesignDocumentRoute = new Route({
+  getParentRoute: () => dashboardProjectLayoutRoute,
+  path: 'design-document',
+  component: DashboardDesignDocumentRoute,
+})
+
 const dashboardProjectJournalRoute = new Route({
   getParentRoute: () => dashboardProjectLayoutRoute,
   path: 'journal',
@@ -110,6 +117,7 @@ const routeTree = rootRoute.addChildren([
     dashboardProjectLayoutRoute.addChildren([
       dashboardProjectIndexRoute,
       dashboardProjectVibePilotRoute,
+      dashboardProjectDesignDocumentRoute,
       dashboardProjectJournalRoute,
       dashboardProjectRitualsRoute,
       dashboardProjectAccountRoute,

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -7,6 +7,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronsUpDown,
+  FileText,
   ListChecks,
   LogIn,
   Menu,
@@ -42,6 +43,12 @@ const sidebarItems = [
     description: 'Spin up an AI copilot for product design and strategy.',
     to: '/dashboard/$projectId/vibe-pilot',
     icon: Bot,
+  },
+  {
+    label: 'Design Doc Builder',
+    description: 'Co-create a polished markdown brief with gentle AI guidance.',
+    to: '/dashboard/$projectId/design-document',
+    icon: FileText,
   },
   {
     label: 'Vibe Journal',

--- a/src/routes/design-document.tsx
+++ b/src/routes/design-document.tsx
@@ -1,0 +1,309 @@
+import React from 'react'
+import { useParams } from '@tanstack/react-router'
+import { AlertCircle, FileText, Loader2 } from 'lucide-react'
+
+import { DesignDocumentWorkspace } from '@/components/ladel/design-document-workspace'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useProjects } from '@/lib/projects'
+import type { VibePilotConfig } from '@/lib/vibe-pilot-ai'
+import {
+  DesignDocumentService,
+  type DesignDocumentServiceState,
+} from '@/services/DesignDocument/service'
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+
+const emptyServiceState: DesignDocumentServiceState = {
+  messages: [],
+  document: '',
+  status: 'draft',
+  isGenerating: false,
+  hasUserInteracted: false,
+  lastSavedAt: null,
+}
+
+export function DashboardDesignDocumentRoute() {
+  const { projectId } = useParams({ from: '/dashboard/$projectId/design-document' })
+  const { activeProject, saveDesignDocument, clearDesignDocument, logProjectActivity } =
+    useProjects()
+  const serviceRef = React.useRef<DesignDocumentService | null>(null)
+  const serviceProjectRef = React.useRef<string | null>(null)
+  const [chatError, setChatError] = React.useState<string | null>(null)
+  const [manualSaveState, setManualSaveState] = React.useState<SaveState>('idle')
+  const [autoSaveState, setAutoSaveState] = React.useState<SaveState>('idle')
+  const [finalizeState, setFinalizeState] = React.useState<SaveState>('idle')
+  const lastSavedContentRef = React.useRef(activeProject?.designDocument?.content ?? '')
+
+  React.useEffect(() => {
+    lastSavedContentRef.current = activeProject?.designDocument?.content ?? ''
+  }, [activeProject?.designDocument?.content])
+
+  const service = React.useMemo(() => {
+    if (!projectId) {
+      return serviceRef.current
+    }
+
+    if (!serviceRef.current || serviceProjectRef.current !== projectId) {
+      const projectName = activeProject?.name ?? 'Untitled project'
+      const initialDocument = activeProject?.designDocument?.content ?? ''
+      const initialStatus = activeProject?.designDocument?.status ?? 'draft'
+      const initialSavedAt = activeProject?.designDocument?.lastSavedAt ?? null
+
+      serviceRef.current = new DesignDocumentService({
+        projectName,
+        initialDocument,
+        initialStatus,
+        initialSavedAt,
+      })
+      serviceProjectRef.current = projectId
+    }
+
+    return serviceRef.current
+  }, [projectId, activeProject])
+
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!service) {
+        return () => {}
+      }
+
+      return service.subscribe(() => onStoreChange())
+    },
+    [service],
+  )
+
+  const serviceState = React.useSyncExternalStore(
+    subscribe,
+    () => service?.getState() ?? emptyServiceState,
+    () => service?.getState() ?? emptyServiceState,
+  )
+
+  const config = React.useMemo<VibePilotConfig>(
+    () => ({
+      mode: 'design',
+      projectName: activeProject?.name ?? 'Untitled project',
+      audience: 'Cross-functional teammates and partners',
+      focusDetails: activeProject?.focus || 'Design document builder session',
+      tone: 'friendly and clear',
+    }),
+    [activeProject?.name, activeProject?.focus],
+  )
+
+  const showDocumentPanel =
+    serviceState.status === 'complete' ||
+    serviceState.document.trim().length > 0 ||
+    serviceState.hasUserInteracted
+
+  const handleSendMessage = React.useCallback(
+    async (message: string) => {
+      setChatError(null)
+      try {
+        await service?.sendMessage(message)
+        logProjectActivity(projectId)
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return
+        }
+        setChatError(error instanceof Error ? error.message : 'Unable to generate a response.')
+      }
+    },
+    [service, logProjectActivity, projectId],
+  )
+
+  const handleMarkdownChange = React.useCallback(
+    (value: string) => {
+      service?.setDocument(value)
+    },
+    [service],
+  )
+
+  const handleManualSave = React.useCallback(async () => {
+    if (!projectId || !service) {
+      return
+    }
+
+    try {
+      setManualSaveState('saving')
+      const saved = await saveDesignDocument(projectId, {
+        content: serviceState.document,
+        status: 'draft',
+        config,
+      })
+
+      if (saved) {
+        lastSavedContentRef.current = saved.content
+        service.markSaved(saved.lastSavedAt)
+        logProjectActivity(projectId)
+        setManualSaveState('saved')
+        window.setTimeout(() => setManualSaveState('idle'), 2500)
+      } else {
+        setManualSaveState('idle')
+      }
+    } catch (error) {
+      console.error(error)
+      setManualSaveState('error')
+      window.setTimeout(() => setManualSaveState('idle'), 2500)
+    }
+  }, [projectId, saveDesignDocument, service, serviceState.document, config, logProjectActivity])
+
+  const handleFinalize = React.useCallback(async () => {
+    if (!projectId || !service || !serviceState.document.trim()) {
+      return
+    }
+
+    try {
+      setFinalizeState('saving')
+      const saved = await saveDesignDocument(projectId, {
+        content: serviceState.document,
+        status: 'complete',
+        config,
+      })
+
+      if (saved) {
+        lastSavedContentRef.current = saved.content
+        service.finalize(saved.lastSavedAt)
+        logProjectActivity(projectId)
+        setFinalizeState('saved')
+        window.setTimeout(() => setFinalizeState('idle'), 2500)
+      } else {
+        setFinalizeState('idle')
+      }
+    } catch (error) {
+      console.error(error)
+      setFinalizeState('error')
+      window.setTimeout(() => setFinalizeState('idle'), 2500)
+    }
+  }, [projectId, saveDesignDocument, service, serviceState.document, config, logProjectActivity])
+
+  const handleReset = React.useCallback(() => {
+    if (!projectId || !service) {
+      return
+    }
+
+    clearDesignDocument(projectId)
+    service.reset()
+    lastSavedContentRef.current = ''
+    setAutoSaveState('idle')
+    setManualSaveState('idle')
+    setFinalizeState('idle')
+    setChatError(null)
+    logProjectActivity(projectId)
+  }, [projectId, clearDesignDocument, service, logProjectActivity])
+
+  React.useEffect(() => {
+    if (!projectId || !service || serviceState.status === 'complete') {
+      return
+    }
+
+    if (lastSavedContentRef.current === serviceState.document) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      try {
+        setAutoSaveState('saving')
+        const saved = saveDesignDocument(projectId, {
+          content: serviceState.document,
+          status: 'draft',
+          config,
+        })
+
+        if (saved) {
+          lastSavedContentRef.current = saved.content
+          service.markSaved(saved.lastSavedAt)
+          logProjectActivity(projectId)
+          setAutoSaveState('saved')
+          window.setTimeout(() => setAutoSaveState('idle'), 2000)
+        } else {
+          setAutoSaveState('idle')
+        }
+      } catch (error) {
+        console.error(error)
+        setAutoSaveState('error')
+        window.setTimeout(() => setAutoSaveState('idle'), 2500)
+      }
+    }, 900)
+
+    return () => window.clearTimeout(timeout)
+  }, [
+    projectId,
+    serviceState.document,
+    serviceState.status,
+    saveDesignDocument,
+    service,
+    config,
+    logProjectActivity,
+  ])
+
+  if (!projectId || !activeProject || activeProject.id !== projectId || !service) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <Loader2
+          className="h-6 w-6 animate-spin text-muted-foreground"
+          aria-label="Loading design document"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-[100dvh] flex-1 flex-col overflow-y-auto bg-muted/20">
+      <section className="border-b border-muted/60 bg-background px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+          <Badge variant="outline" className="w-fit border-primary/50 text-primary">
+            Design toolkit
+          </Badge>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Design Document Builder
+          </h1>
+          <p className="max-w-3xl text-base text-muted-foreground sm:text-lg">
+            Collaborate with our AI partner to turn quick notes into a polished plan for{' '}
+            {activeProject.name}. Share what you know, answer a few guided questions, and watch the
+            markdown preview update in real time.
+          </p>
+          <Card className="border border-muted/60 bg-card">
+            <CardContent className="flex flex-col gap-3 p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                <FileText className="h-4 w-4 text-primary" />
+                <div>
+                  <p className="font-medium text-foreground">How it works</p>
+                  <p>
+                    Chat in plain language. I&apos;ll keep the conversation human and update the
+                    document with structured sections, ready to share.
+                  </p>
+                </div>
+              </div>
+              <Button variant="outline" size="sm" className="gap-2" onClick={handleReset}>
+                <AlertCircle className="h-4 w-4" /> Reset workspace
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+      <section className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex w-full max-w-6xl flex-1 flex-col">
+          <DesignDocumentWorkspace
+            chatMessages={serviceState.messages}
+            onSendMessage={handleSendMessage}
+            chatIsGenerating={serviceState.isGenerating}
+            chatError={chatError}
+            chatDisabled={serviceState.status === 'complete'}
+            markdownValue={serviceState.document}
+            onMarkdownChange={handleMarkdownChange}
+            markdownStatus={serviceState.status}
+            lastSavedAt={serviceState.lastSavedAt}
+            autoSaveState={autoSaveState}
+            manualSaveState={manualSaveState}
+            finalizeState={finalizeState}
+            onManualSave={handleManualSave}
+            onReset={handleReset}
+            onFinalize={handleFinalize}
+            showDocumentPanel={showDocumentPanel}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/services/DesignDocument/service.test.ts
+++ b/src/services/DesignDocument/service.test.ts
@@ -102,6 +102,38 @@ describe('DesignDocumentService', () => {
     expect(state.document).toBe('# Plan\n\nDetails about next steps.')
   })
 
+  it('parses document section when the label is indented', async () => {
+    const request = vi.fn().mockResolvedValue({
+      content: [
+        'Chat:',
+        'Captured the latest structure and applied the requested edits.',
+        '',
+        '    Document:',
+        '# Updated Outline',
+        '',
+        '- Step one',
+      ].join('\n'),
+      isMock: false,
+    })
+
+    const service = new DesignDocumentService({
+      projectName: 'Glow Deck',
+      requestCompletion: request,
+    })
+
+    await service.sendMessage('reformat with indentation in the label')
+
+    const state = service.getState()
+    const assistantMessage = state.messages.find(
+      (message) => message.role === 'assistant' && message.id !== 'seed',
+    )
+
+    expect(assistantMessage?.content).toBe(
+      'Captured the latest structure and applied the requested edits.',
+    )
+    expect(state.document).toBe('# Updated Outline\n\n- Step one')
+  })
+
   it('tracks save events and allows reset and finalize flows', () => {
     const service = new DesignDocumentService({
       projectName: 'Glow Deck',

--- a/src/services/DesignDocument/service.test.ts
+++ b/src/services/DesignDocument/service.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DesignDocumentService } from './service'
+
+describe('DesignDocumentService', () => {
+  it('initializes with provided document state', () => {
+    const service = new DesignDocumentService({
+      projectName: 'Lunar Interfaces',
+      initialDocument: '# Hello\n',
+      initialStatus: 'complete',
+      initialSavedAt: '2024-01-01T00:00:00.000Z',
+    })
+
+    const state = service.getState()
+
+    expect(state.document.trim()).toBe('# Hello')
+    expect(state.status).toBe('complete')
+    expect(state.hasUserInteracted).toBe(false)
+    expect(state.messages.at(0)?.role).toBe('assistant')
+  })
+
+  it('records user messages and produces assistant responses with markdown updates', async () => {
+    const request = vi.fn().mockResolvedValue({
+      content: 'Chat:\nGreat start!\n\nDocument:\n# Intro\n\nWelcome to the doc.',
+      isMock: false,
+    })
+
+    const service = new DesignDocumentService({
+      projectName: 'Glow Deck',
+      requestCompletion: request,
+    })
+
+    await service.sendMessage(' outline the kickoff ')
+
+    const state = service.getState()
+    const userMessage = state.messages.find((message) => message.role === 'user')
+    const assistantMessage = state.messages.find(
+      (message) => message.role === 'assistant' && message.id !== 'seed',
+    )
+
+    expect(userMessage?.content).toBe('outline the kickoff')
+    expect(assistantMessage?.content).toContain('Great start!')
+    expect(state.document).toContain('# Intro')
+    expect(state.hasUserInteracted).toBe(true)
+    expect(request).toHaveBeenCalledTimes(1)
+    const call = request.mock.calls[0][0]
+    expect(call.systemPrompt).toContain('Speak like a friendly product partner')
+    expect(call.systemPrompt).toContain('Document section must be valid Markdown')
+    expect(call.existingDocument).toBe('')
+    expect(call.messages.at(-1)?.content).toBe('outline the kickoff')
+  })
+
+  it('normalizes markdown content to remove duplicate headings', async () => {
+    const request = vi.fn().mockResolvedValue({
+      content: 'Chat:\nHere is the cleaned draft.\n\nDocument:\n# Intro\n\n# Intro\nRepeated',
+      isMock: false,
+    })
+
+    const service = new DesignDocumentService({
+      projectName: 'Glow Deck',
+      requestCompletion: request,
+    })
+
+    await service.sendMessage('please polish the intro')
+
+    const state = service.getState()
+    const introCount = state.document
+      .split('\n')
+      .filter((line) => line.trim().toLowerCase().startsWith('# intro')).length
+    expect(introCount).toBe(1)
+  })
+
+  it('tracks save events and allows reset and finalize flows', () => {
+    const service = new DesignDocumentService({
+      projectName: 'Glow Deck',
+      initialDocument: '# Draft',
+      initialSavedAt: '2024-04-01T08:00:00.000Z',
+    })
+
+    service.markSaved('2024-04-01T08:00:00.000Z')
+    service.finalize('2024-04-02T10:30:00.000Z')
+
+    let state = service.getState()
+    expect(state.status).toBe('complete')
+    expect(state.lastSavedAt).toBe('2024-04-02T10:30:00.000Z')
+
+    service.reset()
+
+    state = service.getState()
+    expect(state.document).toBe('')
+    expect(state.status).toBe('draft')
+    expect(state.hasUserInteracted).toBe(false)
+    expect(state.messages.length).toBeGreaterThan(0)
+  })
+})

--- a/src/services/DesignDocument/service.test.ts
+++ b/src/services/DesignDocument/service.test.ts
@@ -70,6 +70,38 @@ describe('DesignDocumentService', () => {
     expect(introCount).toBe(1)
   })
 
+  it('parses document section when chat references the word document', async () => {
+    const request = vi.fn().mockResolvedValue({
+      content: [
+        'Chat:',
+        'Here is a quick summary of the document: we clarified the flows.',
+        '',
+        'Document:',
+        '# Plan',
+        '',
+        'Details about next steps.',
+      ].join('\n'),
+      isMock: false,
+    })
+
+    const service = new DesignDocumentService({
+      projectName: 'Glow Deck',
+      requestCompletion: request,
+    })
+
+    await service.sendMessage('summarize updates')
+
+    const state = service.getState()
+    const assistantMessage = state.messages.find(
+      (message) => message.role === 'assistant' && message.id !== 'seed',
+    )
+
+    expect(assistantMessage?.content).toBe(
+      'Here is a quick summary of the document: we clarified the flows.',
+    )
+    expect(state.document).toBe('# Plan\n\nDetails about next steps.')
+  })
+
   it('tracks save events and allows reset and finalize flows', () => {
     const service = new DesignDocumentService({
       projectName: 'Glow Deck',

--- a/src/services/DesignDocument/service.ts
+++ b/src/services/DesignDocument/service.ts
@@ -299,7 +299,7 @@ function parseAssistantResponse(raw: string) {
     return { chat: 'I captured your notes.', document: '' }
   }
 
-  const docLabel = /^Document\s*:/im
+  const docLabel = /^\s*Document\s*:/im
   const docMatch = docLabel.exec(normalized)
 
   if (!docMatch) {

--- a/src/services/DesignDocument/service.ts
+++ b/src/services/DesignDocument/service.ts
@@ -299,7 +299,8 @@ function parseAssistantResponse(raw: string) {
     return { chat: 'I captured your notes.', document: '' }
   }
 
-  const docLabel = /^\s*Document\s*:/im
+  const docLabel =
+    /^\s*(?:> ?)*?(?:[-*+]\s+|\d+\.\s+|#{1,6}\s+)?(?:[*_`~]{0,3})?Document(?:[*_`~]{0,3})?\s*:/im
   const docMatch = docLabel.exec(normalized)
 
   if (!docMatch) {

--- a/src/services/DesignDocument/service.ts
+++ b/src/services/DesignDocument/service.ts
@@ -285,7 +285,7 @@ function parseAssistantResponse(raw: string) {
     return { chat: 'I captured your notes.', document: '' }
   }
 
-  const docLabel = /\bDocument\s*:/i
+  const docLabel = /^Document\s*:/im
   const docMatch = docLabel.exec(normalized)
 
   if (!docMatch) {

--- a/src/services/DesignDocument/service.ts
+++ b/src/services/DesignDocument/service.ts
@@ -1,0 +1,412 @@
+import { unified } from 'unified'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import remarkStringify from 'remark-stringify'
+
+import type { ProjectDesignDocumentStatus } from '@/lib/projects'
+
+type MessageRole = 'user' | 'assistant'
+
+type CompletionPayload = {
+  systemPrompt: string
+  messages: Array<{ role: MessageRole; content: string }>
+  existingDocument: string
+  signal?: AbortSignal
+}
+
+type CompletionResponse = {
+  content: string
+  isMock: boolean
+}
+
+type RequestCompletion = (payload: CompletionPayload) => Promise<CompletionResponse>
+
+type DesignDocumentServiceOptions = {
+  projectName: string
+  initialDocument?: string
+  initialStatus?: ProjectDesignDocumentStatus
+  initialSavedAt?: string | null
+  requestCompletion?: RequestCompletion
+}
+
+export type DesignDocumentMessage = {
+  id: string
+  role: MessageRole
+  content: string
+}
+
+export type DesignDocumentServiceState = {
+  messages: DesignDocumentMessage[]
+  document: string
+  status: ProjectDesignDocumentStatus
+  isGenerating: boolean
+  hasUserInteracted: boolean
+  lastSavedAt: string | null
+}
+
+const DEFAULT_MODEL = 'gpt-4o'
+const SEED_MESSAGE_ID = 'seed'
+
+const model = import.meta.env.VITE_OPENAI_MODEL?.trim() || DEFAULT_MODEL
+const completionsUrl =
+  import.meta.env.VITE_VIBE_PILOT_COMPLETIONS_URL?.trim() ||
+  (import.meta.env.DEV ? 'http://localhost:8787/v1/chat/completions' : undefined)
+
+export class DesignDocumentService {
+  private readonly projectName: string
+  private readonly requestCompletion: RequestCompletion
+  private readonly listeners = new Set<(state: DesignDocumentServiceState) => void>()
+  private state: DesignDocumentServiceState
+
+  constructor(options: DesignDocumentServiceOptions) {
+    this.projectName = options.projectName.trim() || 'Untitled project'
+    this.requestCompletion = options.requestCompletion ?? defaultRequestCompletion
+
+    const initialDocument = normalizeDocument(options.initialDocument ?? '')
+    const initialStatus: ProjectDesignDocumentStatus = options.initialStatus ?? 'draft'
+
+    this.state = {
+      messages: [createSeedMessage(this.projectName)],
+      document: initialDocument,
+      status: initialStatus,
+      isGenerating: false,
+      hasUserInteracted: false,
+      lastSavedAt: options.initialSavedAt ?? null,
+    }
+  }
+
+  getState(): DesignDocumentServiceState {
+    return this.state
+  }
+
+  subscribe(listener: (state: DesignDocumentServiceState) => void): () => void {
+    this.listeners.add(listener)
+    listener(this.state)
+
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  async sendMessage(content: string, options?: { signal?: AbortSignal }): Promise<void> {
+    const trimmed = content.trim()
+
+    if (!trimmed) {
+      return
+    }
+
+    if (this.state.isGenerating) {
+      throw new Error('A response is already being generated.')
+    }
+
+    const userMessage: DesignDocumentMessage = {
+      id: createId('user'),
+      role: 'user',
+      content: trimmed,
+    }
+
+    this.updateState({
+      messages: [...this.state.messages, userMessage],
+      hasUserInteracted: true,
+      isGenerating: true,
+    })
+
+    try {
+      const payload: CompletionPayload = {
+        systemPrompt: this.buildSystemPrompt(),
+        messages: this.state.messages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+        existingDocument: this.state.document,
+        signal: options?.signal,
+      }
+
+      const completion = await this.requestCompletion(payload)
+      const parsed = parseAssistantResponse(completion.content)
+
+      const assistantMessage: DesignDocumentMessage = {
+        id: createId('assistant'),
+        role: 'assistant',
+        content: parsed.chat,
+      }
+
+      const nextMessages = [...this.state.messages, assistantMessage]
+      const nextDocument = parsed.document
+        ? normalizeDocument(parsed.document)
+        : this.state.document
+
+      this.updateState({
+        messages: nextMessages,
+        document: nextDocument,
+        isGenerating: false,
+      })
+    } catch (error) {
+      this.updateState({ isGenerating: false })
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error
+      }
+      throw error instanceof Error ? error : new Error('Unable to generate a response.')
+    }
+  }
+
+  setDocument(content: string) {
+    const normalized = normalizeDocument(content)
+
+    this.updateState({
+      document: normalized,
+      hasUserInteracted: this.state.hasUserInteracted || normalized.length > 0,
+    })
+  }
+
+  markSaved(timestamp: string) {
+    this.updateState({ lastSavedAt: timestamp })
+  }
+
+  finalize(timestamp: string) {
+    this.updateState({ status: 'complete', lastSavedAt: timestamp })
+  }
+
+  reset() {
+    this.state = {
+      messages: [createSeedMessage(this.projectName)],
+      document: '',
+      status: 'draft',
+      isGenerating: false,
+      hasUserInteracted: false,
+      lastSavedAt: null,
+    }
+    this.emit()
+  }
+
+  private buildSystemPrompt() {
+    const existingDocument = this.state.document.trim()
+    const documentSection = existingDocument
+      ? `Current design document draft (keep structure unless the user asks to restructure):\n${existingDocument}\n\n`
+      : 'Current design document draft: (empty)\n\n'
+
+    return [
+      'You are Nightshift, a design document partner helping a non-technical founder capture a polished plan.',
+      `Project name: ${this.projectName}.`,
+      documentSection,
+      'Speak like a friendly product partner. Use warm, plain language and short paragraphs.',
+      'Ask at most one simple follow-up question if you truly need more detail. Keep it easy to answer.',
+      'Respond using two sections labeled exactly as "Chat:" and "Document:".',
+      'The Chat section should summarize progress, highlight what changed, and gently guide the next question.',
+      'The Document section must be valid Markdown ready to share with stakeholders. Preserve helpful context from the current draft and tighten phrasing instead of duplicating sections.',
+      'Ensure headings remain unique. Remove duplicate or empty sections.',
+      'Focus on clarity: goals, requirements, users, flows, success signals, risks, and next steps.',
+    ].join('\n')
+  }
+
+  private updateState(partial: Partial<DesignDocumentServiceState>) {
+    this.state = { ...this.state, ...partial }
+    this.emit()
+  }
+
+  private emit() {
+    for (const listener of this.listeners) {
+      listener(this.state)
+    }
+  }
+}
+
+function createSeedMessage(projectName: string): DesignDocumentMessage {
+  return {
+    id: SEED_MESSAGE_ID,
+    role: 'assistant',
+    content: [
+      `Hey there! Let’s capture the essentials for ${projectName}.`,
+      'Share what you are building, who it is for, and any must-have outcomes. I’ll turn it into a clean design doc.',
+    ].join(' '),
+  }
+}
+
+function createId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+function normalizeDocument(input: string) {
+  let cleaned = input
+
+  try {
+    const processed = unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkStringify, { bullet: '-', fences: true, listItemIndent: 'one' })
+      .processSync(input)
+    cleaned = String(processed)
+  } catch (error) {
+    console.error('Failed to normalize markdown with remark', error)
+  }
+
+  const normalized = cleaned.replace(/\r\n/g, '\n').split('\n')
+  const result: string[] = []
+  let previousBlank = false
+  let lastHeadingSlug: string | null = null
+
+  for (const rawLine of normalized) {
+    const line = rawLine.replace(/\s+$/g, '')
+    const trimmed = line.trim()
+
+    if (!trimmed) {
+      if (!previousBlank && result.length > 0) {
+        result.push('')
+      }
+      previousBlank = true
+      continue
+    }
+
+    const headingMatch = /^#{1,6}\s+/.test(trimmed)
+    if (headingMatch) {
+      const slug = trimmed.replace(/\s+/g, ' ').toLowerCase()
+
+      if (slug === lastHeadingSlug) {
+        previousBlank = false
+        continue
+      }
+
+      lastHeadingSlug = slug
+    } else {
+      lastHeadingSlug = null
+    }
+
+    result.push(line)
+    previousBlank = false
+  }
+
+  return result.join('\n').trim()
+}
+
+function parseAssistantResponse(raw: string) {
+  const normalized = raw.replace(/\r\n/g, '\n').trim()
+
+  if (!normalized) {
+    return { chat: 'I captured your notes.', document: '' }
+  }
+
+  const docLabel = /\bDocument\s*:/i
+  const docMatch = docLabel.exec(normalized)
+
+  if (!docMatch) {
+    const chat = normalized.replace(/^Chat\s*:/i, '').trim() || normalized
+    return { chat, document: '' }
+  }
+
+  const index = docMatch.index
+  const before = normalized.slice(0, index)
+  const after = normalized.slice(index + docMatch[0].length)
+
+  const chat = before.replace(/^Chat\s*:/i, '').trim() || 'Here’s the latest update.'
+  const document = after.trim()
+
+  return { chat, document }
+}
+
+const defaultRequestCompletion: RequestCompletion = async ({
+  systemPrompt,
+  messages,
+  existingDocument: _existingDocument,
+  signal,
+}) => {
+  void _existingDocument
+
+  if (!completionsUrl) {
+    const mock = buildMockResponse(messages)
+    return { content: mock, isMock: true }
+  }
+
+  const payload = {
+    model,
+    temperature: 0.4,
+    messages: [
+      { role: 'system' as const, content: systemPrompt },
+      ...messages.map((message) => ({ role: message.role, content: message.content })),
+    ],
+  }
+
+  let response: Response
+
+  try {
+    response = await fetch(completionsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
+    throw new Error('Unable to reach the design document completion service.')
+  }
+
+  if (!response.ok) {
+    const body = await safeParseError(response)
+    throw new Error(body ?? 'The completion service returned an error.')
+  }
+
+  const data = (await response.json()) as {
+    content?: string | null
+    choices?: Array<{ message?: { content?: string | null } }>
+  }
+
+  const directContent = typeof data.content === 'string' ? data.content : null
+  const content = (directContent ?? data.choices?.[0]?.message?.content)?.trim()
+
+  if (!content) {
+    throw new Error('The completion service returned an empty response. Try again shortly.')
+  }
+
+  return { content, isMock: false }
+}
+
+function buildMockResponse(messages: Array<{ role: MessageRole; content: string }>) {
+  const latestUser = [...messages].reverse().find((message) => message.role === 'user')
+  const snippet = latestUser?.content ?? ''
+  const points = snippet
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4)
+    .map((line) => `- ${line}`)
+
+  const outline = points.length
+    ? points.join('\n')
+    : '- Outline the purpose of this release.\n- Capture who benefits and how success is measured.'
+
+  return [
+    'Chat:',
+    'Here’s a quick draft so you can keep working while the live AI connection is offline.',
+    'Add more detail and I’ll reshape the sections for you.',
+    '',
+    'Document:',
+    '# Design Overview',
+    '',
+    '## Summary',
+    outline,
+    '',
+    '## Open Questions',
+    '- What decisions still need feedback?',
+    '- Which risks should we call out for stakeholders?',
+  ].join('\n')
+}
+
+async function safeParseError(response: Response) {
+  try {
+    const data = await response.json()
+    const message =
+      typeof data?.error?.message === 'string'
+        ? data.error.message
+        : typeof data?.message === 'string'
+          ? data.message
+          : null
+    return message
+  } catch (error) {
+    console.error('Failed to parse design document completion error payload', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
* add a dedicated `/design-document` dashboard route that wires the design doc workspace into project state with auto-save, reset, and finalize controls. 【F:src/routes/design-document.tsx†L1-L307】
* implement a `DesignDocumentService` with markdown normalization via remark, chat prompting, and unit tests covering initialization, completions, normalization, and reset/finalize flows. 【F:src/services/DesignDocument/service.ts†L1-L399】【F:src/services/DesignDocument/service.test.ts†L1-L95】
* create ladel chat/markdown workspace components that provide desktop split view and mobile tabs, reusing shadcn/ui primitives. 【F:src/components/ladel/design-document-chat.tsx†L1-L152】【F:src/components/ladel/design-document-markdown-panel.tsx†L1-L239】【F:src/components/ladel/design-document-workspace.tsx†L1-L166】【F:src/components/ladel/design-document-preview.tsx†L1-L105】
* register the builder in router/sidebar navigation and add a Playwright spec intended to capture a screenshot of the new flow. 【F:src/router.tsx†L1-L125】【F:src/routes/dashboard.tsx†L1-L65】【F:playwright/tests/design-document.spec.ts†L1-L24】

## Testing
* `npm run lint`
* `npm run typecheck`
* `npm run test`
* ⚠️ `npx playwright test playwright/tests/design-document.spec.ts --project=chromium` *(blocked: Playwright browsers cannot be downloaded in this environment — see log for HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d36b8eadbc83299a8bd7bc0a58b6d4