### PR TITLE
feat: add prompt optimizer service

### DIFF
--- a/src/services/PromtOptimizer/index.ts
+++ b/src/services/PromtOptimizer/index.ts
@@ -1,0 +1,186 @@
+export type CodingAgent = 'Codex' | 'Cursor' | 'Claude Code'
+
+export type MPCServerDescriptor = {
+  Name: string
+  Context: string
+}
+
+export type OptimizePromptOptions = {
+  userPrompt: string
+  agent: CodingAgent
+  mpcServers: MPCServerDescriptor[]
+  signal?: AbortSignal
+}
+
+type NormalizedMpcServer = {
+  name: string
+  context: string
+}
+
+const DEFAULT_MODEL = 'gpt-4o'
+
+const AGENT_GUIDANCE: Record<CodingAgent, string> = {
+  Codex:
+    'Codex responds best to precise implementation details, code structure guidance, and explicit testing expectations. Highlight languages, frameworks, and success criteria.',
+  Cursor:
+    'Cursor is an IDE-native assistant. Break work into iterative steps, call out key files or commands, and show how to use in-editor tools or context awareness.',
+  'Claude Code':
+    'Claude Code thrives on well-organized instructions, scoped deliverables, and thoughtful guardrails. Emphasize careful reasoning, constraints, and review checkpoints.',
+}
+
+export async function optimizePrompt({
+  userPrompt,
+  agent,
+  mpcServers,
+  signal,
+}: OptimizePromptOptions): Promise<string> {
+  const trimmedPrompt = userPrompt.trim()
+  if (!trimmedPrompt) {
+    throw new Error('A user prompt is required to optimize.')
+  }
+
+  const completionsUrl = resolveCompletionsUrl()
+  if (!completionsUrl) {
+    throw new Error(
+      'The prompt optimization service is not configured. Set VITE_PROMT_OPTIMIZER_COMPLETIONS_URL or VITE_VIBE_PILOT_COMPLETIONS_URL to your OpenAI proxy endpoint.',
+    )
+  }
+
+  const normalizedServers = normalizeServers(mpcServers)
+  const messages = buildPromptMessages({ agent, prompt: trimmedPrompt, servers: normalizedServers })
+  const payload = {
+    model: resolveModel(),
+    temperature: 0.3,
+    messages,
+  }
+
+  let response: Response
+  try {
+    response = await fetch(completionsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
+
+    throw new Error('Unable to reach the prompt optimization proxy.')
+  }
+
+  if (!response.ok) {
+    const message = await parseProxyError(response)
+    throw new Error(message ?? 'The prompt optimization proxy responded with an error.')
+  }
+
+  const data = (await response.json()) as {
+    content?: string | null
+    choices?: Array<{ message?: { content?: string | null } | null }>
+  }
+
+  const directContent = typeof data.content === 'string' ? data.content : null
+  const optimized = (directContent ?? data.choices?.[0]?.message?.content ?? '').trim()
+
+  if (!optimized) {
+    throw new Error('The prompt optimization proxy returned an empty response. Try again shortly.')
+  }
+
+  return optimized
+}
+
+function resolveCompletionsUrl(): string | null {
+  const explicit = import.meta.env.VITE_PROMT_OPTIMIZER_COMPLETIONS_URL?.trim()
+  if (explicit) {
+    return explicit
+  }
+
+  const vibePilotUrl = import.meta.env.VITE_VIBE_PILOT_COMPLETIONS_URL?.trim()
+  if (vibePilotUrl) {
+    return vibePilotUrl
+  }
+
+  if (import.meta.env.DEV) {
+    return 'http://localhost:8787/v1/chat/completions'
+  }
+
+  return null
+}
+
+function resolveModel(): string {
+  return (
+    import.meta.env.VITE_PROMT_OPTIMIZER_MODEL?.trim() ||
+    import.meta.env.VITE_OPENAI_MODEL?.trim() ||
+    DEFAULT_MODEL
+  )
+}
+
+function normalizeServers(servers: MPCServerDescriptor[]): NormalizedMpcServer[] {
+  return servers
+    .map((server) => ({
+      name: server.Name?.trim() ?? '',
+      context: server.Context?.trim() ?? '',
+    }))
+    .filter((server): server is NormalizedMpcServer => Boolean(server.name && server.context))
+}
+
+function buildPromptMessages({
+  agent,
+  prompt,
+  servers,
+}: {
+  agent: CodingAgent
+  prompt: string
+  servers: NormalizedMpcServer[]
+}) {
+  const systemContent = [
+    'You are an elite prompt engineer who rewrites software development prompts for coding agents.',
+    `Target assistant: ${agent}.`,
+    AGENT_GUIDANCE[agent],
+    'Deliver a single, production-ready prompt optimized for the target assistant. Reference available MPC servers when they can help the work.',
+    'Return only the optimized prompt with no additional commentary or roleplay.',
+  ].join(' ')
+
+  const serverSection =
+    servers.length > 0
+      ? [
+          'MPC servers available:',
+          ...servers.map((server) => `- ${server.name}: ${server.context}`),
+        ].join('\n')
+      : 'MPC servers available:\n- None provided; note when additional context would be helpful.'
+
+  const userContent = [
+    serverSection,
+    '',
+    'Rewrite the following user request so that it becomes a highly detailed, success-oriented brief for the target coding agent. Clarify deliverables, coding standards, tests, edge cases, and how to leverage MPC servers where applicable.',
+    'Original prompt:',
+    '"""',
+    prompt,
+    '"""',
+  ].join('\n')
+
+  return [
+    { role: 'system' as const, content: systemContent },
+    { role: 'user' as const, content: userContent },
+  ]
+}
+
+async function parseProxyError(response: Response) {
+  try {
+    const data = await response.json()
+    if (typeof data?.error?.message === 'string') {
+      return data.error.message
+    }
+    if (typeof data?.message === 'string') {
+      return data.message
+    }
+    return null
+  } catch (error) {
+    console.error('Failed to parse prompt optimizer error payload', error)
+    return null
+  }
+}

--- a/src/services/PromtOptimizer/prompt-optimizer.test.ts
+++ b/src/services/PromtOptimizer/prompt-optimizer.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('optimizePrompt', () => {
+  const completionsUrl = 'https://proxy.test/v1/chat/completions'
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_PROMT_OPTIMIZER_COMPLETIONS_URL', completionsUrl)
+    vi.stubEnv('VITE_PROMT_OPTIMIZER_MODEL', 'gpt-4o')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('sends a formatted optimization request to the proxy', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: 'Optimized prompt for Cursor' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { optimizePrompt } = await import('./index')
+
+    const optimized = await optimizePrompt({
+      userPrompt: 'Build a dashboard for tracking KPIs',
+      agent: 'Cursor',
+      mpcServers: [
+        { Name: 'Context7', Context: 'Use Context7 to reference all documentation' },
+        { Name: 'MetricsDB', Context: 'Holds KPI calculation guidelines' },
+      ],
+    })
+
+    expect(optimized).toBe('Optimized prompt for Cursor')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(completionsUrl)
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    })
+
+    const body = JSON.parse(String(init?.body))
+    expect(body.model).toBe('gpt-4o')
+    expect(body.messages).toHaveLength(2)
+    const [systemMessage, userMessage] = body.messages
+    expect(systemMessage).toMatchObject({ role: 'system' })
+    expect(systemMessage.content).toContain('Cursor')
+    expect(userMessage.content).toContain('Build a dashboard for tracking KPIs')
+    expect(userMessage.content).toContain('Context7')
+    expect(userMessage.content).toContain('MetricsDB')
+  })
+
+  it('falls back to the first choice message when content is not provided directly', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          { message: { content: 'Refined prompt for Codex' } },
+          { message: { content: 'Another option' } },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { optimizePrompt } = await import('./index')
+
+    const optimized = await optimizePrompt({
+      userPrompt: 'Refactor the authentication module',
+      agent: 'Codex',
+      mpcServers: [],
+    })
+
+    expect(optimized).toBe('Refined prompt for Codex')
+  })
+
+  it('throws a helpful error when the proxy responds with an error message', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { message: 'Upstream failure' } }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { optimizePrompt } = await import('./index')
+
+    await expect(
+      optimizePrompt({
+        userPrompt: 'Implement a realtime notification service',
+        agent: 'Claude Code',
+        mpcServers: [],
+      }),
+    ).rejects.toThrow('Upstream failure')
+  })
+
+  it('requires a non-empty user prompt', async () => {
+    const { optimizePrompt } = await import('./index')
+
+    await expect(
+      optimizePrompt({
+        userPrompt: '   ',
+        agent: 'Cursor',
+        mpcServers: [],
+      }),
+    ).rejects.toThrow('A user prompt is required to optimize.')
+  })
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,6 +9,10 @@ interface ImportMetaEnv {
   readonly VITE_STRIPE_PRICE_ID_SCALE?: string
   readonly VITE_STRIPE_SUCCESS_URL?: string
   readonly VITE_STRIPE_CANCEL_URL?: string
+  readonly VITE_PROMT_OPTIMIZER_COMPLETIONS_URL?: string
+  readonly VITE_PROMT_OPTIMIZER_MODEL?: string
+  readonly VITE_VIBE_PILOT_COMPLETIONS_URL?: string
+  readonly VITE_OPENAI_MODEL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add a prompt optimizer service that formats user prompts and routes them through the OpenAI proxy
- normalize MPC server metadata and tailor system instructions to each supported coding agent
- cover the service with Vitest unit tests and document new environment variables

## Testing
- npm run test
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3dc6072288329ab3cebc9f28f562b